### PR TITLE
config の棚卸し・削減（挙動は維持）

### DIFF
--- a/.config/aerospace/aerospace.toml
+++ b/.config/aerospace/aerospace.toml
@@ -1,55 +1,24 @@
-# Place a copy of this config to ~/.aerospace.toml
-# After that, you can edit ~/.aerospace.toml to your liking
+# AeroSpace config. Docs: https://nikitabobko.github.io/AeroSpace/guide
+# Symlinked to ~/.config/aerospace/aerospace.toml
 
-# You can use it to add commands that run after AeroSpace startup.
-# Available commands : https://nikitabobko.github.io/AeroSpace/commands
-after-startup-command = []
-
-# Start AeroSpace at login
 start-at-login = false
 
-# Normalizations. See: https://nikitabobko.github.io/AeroSpace/guide#normalization
+# Normalizations
 enable-normalization-flatten-containers = true
 enable-normalization-opposite-orientation-for-nested-containers = true
 
-# See: https://nikitabobko.github.io/AeroSpace/guide#layouts
-# The 'accordion-padding' specifies the size of accordion padding
-# You can set 0 to disable the padding feature
 accordion-padding = 30
-
-# Possible values: tiles|accordion
 default-root-container-layout = 'tiles'
-
-# Possible values: horizontal|vertical|auto
-# 'auto' means: wide monitor (anything wider than high) gets horizontal orientation,
-#               tall monitor (anything higher than wide) gets vertical orientation
 default-root-container-orientation = 'auto'
 
-# Mouse follows focus when focused monitor changes
-# Drop it from your config, if you don't like this behavior
-# See https://nikitabobko.github.io/AeroSpace/guide#on-focus-changed-callbacks
-# See https://nikitabobko.github.io/AeroSpace/commands#move-mouse
-# Fallback value (if you omit the key): on-focused-monitor-changed = []
+# Mouse follows focus when the focused monitor changes
 on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 
-# You can effectively turn off macOS "Hide application" (cmd-h) feature by toggling this flag
-# Useful if you don't use this macOS feature, but accidentally hit cmd-h or cmd-alt-h key
-# Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
 automatically-unhide-macos-hidden-apps = false
 
-# Possible values: (qwerty|dvorak|colemak)
-# See https://nikitabobko.github.io/AeroSpace/guide#key-mapping
 [key-mapping]
     preset = 'qwerty'
 
-# Gaps between windows (inner-*) and between monitor edges (outer-*).
-# Possible values:
-# - Constant:     gaps.outer.top = 8
-# - Per monitor:  gaps.outer.top = [{ monitor.main = 16 }, { monitor."some-pattern" = 32 }, 24]
-#                 In this example, 24 is a default value when there is no match.
-#                 Monitor pattern is the same as for 'workspace-to-monitor-force-assignment'.
-#                 See:
-#                 https://nikitabobko.github.io/AeroSpace/guide#assign-workspaces-to-monitors
 [gaps]
     inner.horizontal = 5
     inner.vertical =   5
@@ -66,61 +35,21 @@ automatically-unhide-macos-hidden-apps = false
     5 = 'secondary'
     6 = 'secondary'
 
-# 'main' binding mode declaration
-# See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
-# 'main' binding mode must be always presented
-# Fallback value (if you omit the key): mode.main.binding = {}
 [mode.main.binding]
-
-    # All possible keys:
-    # - Letters.        a, b, c, ..., z
-    # - Numbers.        0, 1, 2, ..., 9
-    # - Keypad numbers. keypad0, keypad1, keypad2, ..., keypad9
-    # - F-keys.         f1, f2, ..., f20
-    # - Special keys.   minus, equal, period, comma, slash, backslash, quote, semicolon,
-    #                   backtick, leftSquareBracket, rightSquareBracket, space, enter, esc,
-    #                   backspace, tab, pageUp, pageDown, home, end, forwardDelete,
-    #                   sectionSign (ISO keyboards only, european keyboards only)
-    # - Keypad special. keypadClear, keypadDecimalMark, keypadDivide, keypadEnter, keypadEqual,
-    #                   keypadMinus, keypadMultiply, keypadPlus
-    # - Arrows.         left, down, up, right
-
-    # All possible modifiers: cmd, alt, ctrl, shift
-
-    # All possible commands: https://nikitabobko.github.io/AeroSpace/commands
-
-    # See: https://nikitabobko.github.io/AeroSpace/commands#exec-and-forget
-    # You can uncomment the following lines to open up terminal with alt + enter shortcut
-    # (like in i3)
-    # alt-enter = '''exec-and-forget osascript -e '
-    # tell application "Terminal"
-    #     do script
-    #     activate
-    # end tell'
-    # '''
-
-    # See: https://nikitabobko.github.io/AeroSpace/commands#layout
-    # alt-slash = 'layout tiles horizontal vertical'
-    # alt-comma = 'layout accordion horizontal vertical'
-
-    # See: https://nikitabobko.github.io/AeroSpace/commands#focus
+    # focus
     cmd-h = 'focus left'
     cmd-j = 'focus down'
     cmd-k = 'focus up'
     cmd-l = 'focus right'
 
-    # See: https://nikitabobko.github.io/AeroSpace/commands#move
+    # move window
     cmd-shift-h = 'move left'
     cmd-shift-j = 'move down'
     cmd-shift-k = 'move up'
     cmd-shift-l = 'move right'
     cmd-shift-f = 'fullscreen'
 
-    # See: https://nikitabobko.github.io/AeroSpace/commands#resize
-    # alt-minus = 'resize smart -50'
-    # alt-equal = 'resize smart +50'
-
-    # See: https://nikitabobko.github.io/AeroSpace/commands#workspace
+    # switch workspace
     cmd-1 = 'workspace 1'
     cmd-2 = 'workspace 2'
     cmd-3 = 'workspace 3'
@@ -128,11 +57,10 @@ automatically-unhide-macos-hidden-apps = false
     cmd-5 = 'workspace 5'
     cmd-6 = 'workspace 6'
 
-    # See: https://nikitabobko.github.io/AeroSpace/commands#move-node-to-workspace
+    # move window to workspace
     cmd-shift-1 = 'move-node-to-workspace 1'
     cmd-shift-2 = 'move-node-to-workspace 2'
     cmd-shift-3 = 'move-node-to-workspace 3'
     cmd-shift-4 = 'move-node-to-workspace 4'
     cmd-shift-5 = 'move-node-to-workspace 5'
     cmd-shift-6 = 'move-node-to-workspace 6'
-

--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -2,3 +2,5 @@
 .worktrees/
 tmp_task.md
 .envrc
+tags
+.solargraph.yml

--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -1,12 +1,7 @@
--- Pull in the wezterm API
 local wezterm = require 'wezterm'
 
--- This will hold the configuration.
 local config = wezterm.config_builder()
 
--- This is where you actually apply your config choices
-
--- For example, changing the color scheme:
 config.color_scheme = 'nightfox'
 config.window_decorations = 'RESIZE'
 config.enable_tab_bar = false
@@ -21,5 +16,4 @@ config.macos_forward_to_ime_modifier_mask = "CTRL"
 
 config.audible_bell = "Disabled"
 
--- and finally, return the configuration to wezterm
 return config

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 .env
-crefre.zsh
-.config/nvim/template/template_spec.rb

--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,3 +1,0 @@
-.envrc
-tags
-.solargraph.yml

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -6,9 +6,6 @@ set -s escape-time 10                     # faster command sequences
 set -sg repeat-time 0                   # increase repeat timeout
 set -s focus-events on
 
-set -q -g status-utf8 on                  # expect UTF-8 (tmux < 2.2)
-setw -q -g utf8 on
-
 set -g history-limit 5000                 # boost history
 
 set-option -g status-position bottom
@@ -74,70 +71,23 @@ set -g status-right-length 150
 set -g status-fg white
 set -g status-bg colour234
 
-# set -g status-left '#[fg=colour235,bg=colour252,bold] #S #[fg=colour252,bg=colour238,nobold]'
-# set -g window-status-format "#[fg=white,bg=colour234] #I #W "
-# set -g window-status-current-format "#[fg=colour234,bg=colour39]#[fg=colour25,bg=colour39,noreverse,bold] #I #W #[fg=colour39,bg=colour234,nobold]"
-# set -g status-right ' #{?client_prefix,Pre,} #[fg=colour255,bg=colour8,bold] #(pmset -g batt | grep [0-9][0-9]% | cut -c 33-36) #[fg=colour238,bg=colour234,nobold]#[fg=colour235,bg=colour252,bold]%y-%b-%d %H:%M'
-
 # -- copy mode -----------------------------------------------------------------
 
 bind Enter copy-mode # enter copy mode
 
-run -b 'tmux bind -t vi-copy v begin-selection 2> /dev/null || true'
-run -b 'tmux bind -T copy-mode-vi v send -X begin-selection 2> /dev/null || true'
-run -b 'tmux bind -t vi-copy C-v rectangle-toggle 2> /dev/null || true'
-run -b 'tmux bind -T copy-mode-vi C-v send -X rectangle-toggle 2> /dev/null || true'
-run -b 'tmux bind -t vi-copy y copy-selection 2> /dev/null || true'
-run -b 'tmux bind -T copy-mode-vi y send -X copy-selection-and-cancel 2> /dev/null || true'
-run -b 'tmux bind -t vi-copy Escape cancel 2> /dev/null || true'
-run -b 'tmux bind -T copy-mode-vi Escape send -X cancel 2> /dev/null || true'
-run -b 'tmux bind -t vi-copy H start-of-line 2> /dev/null || true'
-run -b 'tmux bind -T copy-mode-vi H send -X start-of-line 2> /dev/null || true'
-run -b 'tmux bind -t vi-copy L end-of-line 2> /dev/null || true'
-run -b 'tmux bind -T copy-mode-vi L send -X end-of-line 2> /dev/null || true'
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi C-v send -X rectangle-toggle
+bind -T copy-mode-vi Escape send -X cancel
+bind -T copy-mode-vi H send -X start-of-line
+bind -T copy-mode-vi L send -X end-of-line
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
 
-run -b 'tmux bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"'
-
-# replace C-b by C-a instead of using both prefixes
+# use C-t as the prefix instead of C-b
 set -gu prefix2
 unbind C-t
 unbind C-b
 set -g prefix C-t
 bind C-t send-prefix
-
-# bind -r p split-window -l 13
-# bind -r p run-shell 'ssh mituba-dev ls | head -n 1 | pbcopy'
-
-# tmuxline.vim
-# source-file ~/.tmuxline.conf
-
-# tpm
-# set -g @plugin 'tmux-plugins/tpm'
-
-# tmux plugins {{{
-# prefix + space: copy tmux buffer
-# prefix + ]: paste tmux buffer data
-# set -g @plugin 'fcsonline/tmux-thumbs'
-
-# prefix + g: move session using keyword
-# set -g @plugin 'tmux-plugins/tmux-sessionist'
-
-### for status line
-# show cpu for status line
-# set -g @plugin 'tmux-plugins/tmux-cpu'
-
-# show online status
-# set -g @plugin 'tmux-plugins/tmux-online-status'
-
-# elly color theme
-# set -g @plugin 'ryuta69/elly-tmux'
-# }}}
-
-# run -b '~/.tmux/plugins/tpm/tpm'
-
-# tmux-thumbs
-# set -g @thumbs-regexp-1 '[a-z]+@[a-z]+.com' # Match emails
-# set -g @thumbs-regexp-2 '[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:' # Match MAC addresses
 
 bind q confirm kill-pane
 


### PR DESCRIPTION
## 概要

各 config を眺めて、**挙動を変えずに**減らせる箇所を整理した。`-149 / +18` 行。

## 変更内容

| ファイル | 削減内容 |
|---|---|
| `tmux/.tmux.conf` | tmux 3.5a で無効な `status-utf8`/`utf8`（元から「< 2.2 専用」コメント付き）、`vi-copy` テーブル（2.4 で廃止）を削除し `copy-mode-vi` に整理（重複していた `y` の上書きも解消）。コメントアウト済みのプラグイン群(tpm, tmux-thumbs, sessionist, cpu 等)/status format の dead コメントを撤去 |
| `.config/aerospace/aerospace.toml` | 公式テンプレ由来の解説コメントと no-op の `after-startup-command = []` を削除（138 → 69 行）。**設定値・キーバインドは全て据え置き** |
| `.config/wezterm/wezterm.lua` | getting-started テンプレのボイラープレートコメントを削除 |
| `.gitignore_global` | **削除**。`core.excludesfile` 未設定・symlink なし・参照元なしで dead と確認（git は XDG 既定の `~/.config/git/ignore`(symlink) を使用中） |
| `.config/git/ignore` | `.gitignore_global` 固有の `tags` / `.solargraph.yml` をここへ移管（global ignore の意図を保持） |
| `.gitignore` | 本リポジトリに存在しないファイルへの stale エントリ(`crefre.zsh`, `.config/nvim/template/template_spec.rb`)を削除し `.env` のみ残す |

## 温存（意図的）

cmux/settings.json、AquaSKK の keymap/kana-rule、zellij layouts、statusline。

## 検証

- tmux: `tmux -f tmux/.tmux.conf new-session -d` でパース成功
- aerospace: 構造不変のため目視確認（AeroSpace.app 未起動で dry-run 不可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)